### PR TITLE
Use the ubuntu/xenial package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Add raintank apt repository
   apt_repository:
-    repo: "deb https://packagecloud.io/raintank/raintank/{{ ansible_lsb.id|lower }}/ {{ ansible_lsb.codename|lower }} main"
+    repo: "deb https://packagecloud.io/raintank/raintank/ubuntu/ xenial main"
 
 - name: Install carbon-relay-ng
   apt:

--- a/test/main.yml
+++ b/test/main.yml
@@ -5,7 +5,7 @@
   vars:
     inventory:
       - name: carbon_relay_ng_host
-        image: "ubuntu:16.04"
+        image: "ubuntu:18.04"
   roles:
     - role: provision_docker
       vars:


### PR DESCRIPTION
Currently the latest carbon-relay-ng package is for xenial.
Always use the xenial package but test with bionic to make sure it
works.

xenial: 16.04
bionic: 18.04