### PR TITLE
Add storage-aggregation.conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: python
 python:
-  - "2.7"
+  - "3.6"
 services:
   - docker
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     state: directory
     owner: carbon-relay-ng
     group: carbon-relay-ng
+    mode: 0755
   notify: Restart carbon-relay-ng service
 
 - name: Copy carbon-relay-ng Supervisord config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,13 @@
     mode: 0644
   notify: Restart carbon-relay-ng service
 
+- name: Copy storage-aggregation file
+  template:
+    src: storage-aggregation.conf
+    dest: "{{ carbon_relay_ng_conf_dir }}/storage-aggregation.conf"
+    mode: 0644
+  notify: Restart carbon-relay-ng service
+
 - name: Create directory for pid file
   file:
     path: "{{ carbon_relay_ng_work_dir }}"

--- a/templates/carbon-relay-ng.conf
+++ b/templates/carbon-relay-ng.conf
@@ -42,6 +42,7 @@ type = "{{ graphite_route_type }}"
 addr = "{{ graphite_addr | mandatory }}"
 apikey =  "{{ graphite_apikey | mandatory }}"
 schemasFile = "{{ carbon_relay_ng_conf_dir }}/storage-schemas.conf"
+aggregationFile = "{{ carbon_relay_ng_conf_dir }}/storage-aggregation.conf"
 
 ## Instrumentation ##
 [instrumentation]

--- a/templates/storage-aggregation.conf
+++ b/templates/storage-aggregation.conf
@@ -1,0 +1,5 @@
+# taken from https://grafana.com/docs/grafana-cloud/how-do-i/visualize-and-store-graphite/
+[default]
+  pattern = .*
+  xFilesFactor = 0.5
+  aggregationMethod = avg

--- a/test/main.yml
+++ b/test/main.yml
@@ -5,15 +5,11 @@
   vars:
     inventory:
       - name: carbon_relay_ng_host
-        image: "ubuntu:18.04"
+        image: "ubuntu:20.04"
   roles:
     - role: provision_docker
       vars:
         provision_docker_inventory: "{{ inventory }}"
-      #Fixes broken pip/Ansible/docker-py
-      #From: https://medium.com/dronzebot/ansible-and-docker-py-path-issues-and-resolving-them-e3834d5bb79a
-      environment:
-        PYTHONPATH: "{{ lookup('env','PYTHONPATH') }}:/usr/local/lib/python2.7/dist-packages:/usr/local/lib/python2.7/site-packages:/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages"
 
 - name: Bootstrap machine for Ansible
   hosts: docker_containers
@@ -28,6 +24,26 @@
   tasks:
     - apt:
         name: sudo
+
+# This package is required in Ubuntu 20.04 to ensure that /usr/bin/python
+# is actually Python 3.
+- name: Install python-is-python3
+  hosts: docker_containers
+  tasks:
+    - apt:
+        name: python-is-python3
+
+# Not sure why we need both Python 2 and Python 3 versions of these packages,
+# but it breaks without them.
+- name: Install setuptools and pkg-resources
+  hosts: docker_containers
+  tasks:
+    - apt:
+        name:
+          - python-pkg-resources
+          - python-setuptools
+          - python3-pkg-resources
+          - python3-setuptools
 
 - name: Roles for docker container
   hosts: docker_containers

--- a/test/main.yml
+++ b/test/main.yml
@@ -38,7 +38,7 @@
     - supervisor
     - role: carbon_relay_ng
       vars:
-        graphite_addr: "localhost"
+        graphite_addr: "http://localhost/metrics"
         graphite_apikey: "dummy"
   post_tasks:
     - wait_for:

--- a/test/requirements.yml
+++ b/test/requirements.yml
@@ -14,4 +14,4 @@
 - name: pip
   src: git@github.com:geerlingguy/ansible-role-pip.git
   scm: git
-  version: 1.2.1
+  version: 2.0.0


### PR DESCRIPTION
Not sure why this is suddenly needed, but without this carbon-relay-ng
fails to start with this error message:

    [INFO] ===== carbon-relay-ng instance 'ip-10-0-3-120' starting. (version 1.0) =====
    [INFO] initializing routing table...
    [ERROR] NewGrafanaNetConfig: could not read aggregationFile "": read .: is a directory
    [ERROR] error adding route 'grafanaNet'