### PR TITLE
Fix wait_for host

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,7 @@
 
 - name: Wait for carbon-relay-ng to start up
   wait_for:
+    host: localhost
     port: "{{ carbon_relay_ng_port }}"
     timeout: "{{ wait_for_startup_timeout }}"
   when: wait_for_startup


### PR DESCRIPTION
Ansible by default waits for a port on host "127.0.0.1".

On some environments (Ubuntu 20.04 travis/docker) carbon_relay_ng starts
up on 127.0.1.1 and ansible_wait_for cannot connect to it. Explicitly
specify localhost in wait_for as a workaround.