### PR TITLE
Install from Github for now

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ carbon_relay_ng_work_dir: /run/carbon-relay-ng
 wait_for_startup: True
 wait_for_startup_timeout: 30
 wait_for_healthcheck: True
+
+install_from_github_release: True

--- a/tasks/install_from_github_release.yml
+++ b/tasks/install_from_github_release.yml
@@ -1,0 +1,40 @@
+- name: Get latest version from Github
+  uri:
+    url: "https://api.github.com/repos/GameAnalytics/carbon-relay-ng/releases/tags/v1.1"
+    return_content: yes
+  register: github_response
+
+- name: Get architecture string
+  set_fact:
+    arch_string: "{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}"
+
+- name: Get package name
+  set_fact:
+    github_binary_filename: "carbon-relay-ng-1.1-1_{{ arch_string }}.deb"
+
+- name: Set fact about asset URL
+  set_fact:
+    binary_asset_url: "{{  github_response.json.assets|json_query(query) }}"
+  vars:
+    query: "[?name=='{{ github_binary_filename }}'].url | [0]"
+  failed_when: not binary_asset_url
+
+- name: Get Binary asset's location
+  uri:
+    url: "{{ binary_asset_url }}"
+    return_content: no
+    follow_redirects: none
+    status_code: 302
+    headers:
+      Accept: "application/octet-stream"
+  register: assets
+
+- name: Download binary release
+  get_url:
+    url: "{{ assets.location }}"
+    dest: "/tmp/{{ github_binary_filename }}"
+    mode: 0644
+
+- name: Install carbon-relay-ng from .deb file
+  apt:
+    deb: "/tmp/{{ github_binary_filename }}"

--- a/tasks/install_with_apt.yml
+++ b/tasks/install_with_apt.yml
@@ -1,0 +1,17 @@
+# Raintank is the repository provided by the team who develops carbon-relay-ng (GrafanaLabs)
+- name: Add https support for apt
+  apt:
+    name: apt-transport-https
+
+- name: Add raintank apt-key
+  apt_key:
+    url: https://packagecloud.io/raintank/raintank/gpgkey
+
+- name: Add raintank apt repository
+  apt_repository:
+    repo: "deb https://packagecloud.io/raintank/raintank/ubuntu/ xenial main"
+
+- name: Install carbon-relay-ng
+  apt:
+    name: carbon-relay-ng
+    update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,13 @@
-# Raintank is the repository provided by the team who develops carbon-relay-ng (GrafanaLabs)
-- name: Add https support for apt
-  apt:
-    name: apt-transport-https
+# The package repository currently doesn't contain ARM64 packages,
+# so we install packages stored in a github release instead.
+#
+# Revisit once https://github.com/grafana/carbon-relay-ng/pull/479
+# is merged.
+- include: install_from_github_release.yml
+  when: install_from_github_release
 
-- name: Add raintank apt-key
-  apt_key:
-    url: https://packagecloud.io/raintank/raintank/gpgkey
-
-- name: Add raintank apt repository
-  apt_repository:
-    repo: "deb https://packagecloud.io/raintank/raintank/ubuntu/ xenial main"
-
-- name: Install carbon-relay-ng
-  apt:
-    name: carbon-relay-ng
-    update_cache: yes
+- include: install_with_apt.yml
+  when: not install_from_github_release
 
 - name: Copy conf file
   template:


### PR DESCRIPTION
The package repository doesn't have packages for ARM.  Let's get
packages from our own Github release assets for now.

Towards GAME-12059.