### PR TITLE
Use unique variable name instead of github_binary_filename

### DIFF
--- a/tasks/install_from_github_release.yml
+++ b/tasks/install_from_github_release.yml
@@ -10,13 +10,13 @@
 
 - name: Get package name
   set_fact:
-    github_binary_filename: "carbon-relay-ng-1.1-1_{{ arch_string }}.deb"
+    carbon_relay_ng_github_binary_filename: "carbon-relay-ng-1.1-1_{{ arch_string }}.deb"
 
 - name: Set fact about asset URL
   set_fact:
     binary_asset_url: "{{  github_response.json.assets|json_query(query) }}"
   vars:
-    query: "[?name=='{{ github_binary_filename }}'].url | [0]"
+    query: "[?name=='{{ carbon_relay_ng_github_binary_filename }}'].url | [0]"
   failed_when: not binary_asset_url
 
 - name: Get Binary asset's location
@@ -32,9 +32,9 @@
 - name: Download binary release
   get_url:
     url: "{{ assets.location }}"
-    dest: "/tmp/{{ github_binary_filename }}"
+    dest: "/tmp/{{ carbon_relay_ng_github_binary_filename }}"
     mode: 0644
 
 - name: Install carbon-relay-ng from .deb file
   apt:
-    deb: "/tmp/{{ github_binary_filename }}"
+    deb: "/tmp/{{ carbon_relay_ng_github_binary_filename }}"


### PR DESCRIPTION
Some other playbooks use github_binary_filename, so overwriting it is
not a good idea.