### PR TITLE
Use github_token in Github requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ install:
 
 script:
   - ansible-playbook -i test/inventory test/main.yml --syntax-check
-  - ansible-playbook -i test/inventory test/main.yml -vvv
+  - ansible-playbook -i test/inventory test/main.yml -e "github_token=${GITHUB_TOKEN}" -vvv
   - ansible-lint .

--- a/tasks/install_from_github_release.yml
+++ b/tasks/install_from_github_release.yml
@@ -1,6 +1,6 @@
 - name: Get latest version from Github
   uri:
-    url: "https://api.github.com/repos/GameAnalytics/carbon-relay-ng/releases/tags/v1.1"
+    url: "https://api.github.com/repos/GameAnalytics/carbon-relay-ng/releases/tags/v1.2.1-rc1"
     return_content: yes
   register: github_response
 
@@ -10,7 +10,7 @@
 
 - name: Get package name
   set_fact:
-    carbon_relay_ng_github_binary_filename: "carbon-relay-ng-1.1-1_{{ arch_string }}.deb"
+    carbon_relay_ng_github_binary_filename: "carbon-relay-ng-1.2.1-rc1-1_{{ arch_string }}.deb"
 
 - name: Set fact about asset URL
   set_fact:

--- a/tasks/install_from_github_release.yml
+++ b/tasks/install_from_github_release.yml
@@ -2,6 +2,8 @@
   uri:
     url: "https://api.github.com/repos/GameAnalytics/carbon-relay-ng/releases/tags/v1.2.1-rc1"
     return_content: yes
+    headers:
+      Authorization: "token {{ github_token }}"
   register: github_response
 
 - name: Get architecture string
@@ -27,6 +29,7 @@
     status_code: 302
     headers:
       Accept: "application/octet-stream"
+      Authorization: "token {{ github_token }}"
   register: assets
 
 - name: Download binary release


### PR DESCRIPTION
This raises API rate limits, compared to unauthenticated requests.

----
Also use carbon-relay-ng version 1.2.1-rc1.