### PR TITLE
Use import_tasks instead of include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,10 @@
 #
 # Revisit once https://github.com/grafana/carbon-relay-ng/pull/479
 # is merged.
-- include: install_from_github_release.yml
+- import_tasks: install_from_github_release.yml
   when: install_from_github_release
 
-- include: install_with_apt.yml
+- import_tasks: install_with_apt.yml
   when: not install_from_github_release
 
 - name: Copy conf file


### PR DESCRIPTION
include has been deprecated:

    ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.