### PR TITLE
Don't use a symlink to run tests

### DIFF
--- a/test/carbon_relay_ng
+++ b/test/carbon_relay_ng
@@ -1,1 +1,0 @@
-../../ansible-carbon-relay-ng

--- a/test/main.yml
+++ b/test/main.yml
@@ -52,7 +52,8 @@
   roles:
     - pip
     - supervisor
-    - role: carbon_relay_ng
+    # We're not allowed to use symlinks or relative paths, so let's do it this way
+    - role: "{{ playbook_dir | regex_replace('/test$', '')}}"
       vars:
         graphite_addr: "http://localhost/metrics"
         graphite_apikey: "dummy"

--- a/test/requirements.yml
+++ b/test/requirements.yml
@@ -1,5 +1,6 @@
 - name: provision_docker
-  src: git@github.com:chrismeyersfsu/provision_docker.git
+  src: git@github.com:GameAnalytics/provision_docker.git
+  version: symlink-subdirs
   scm: git
 
 - name: bootstrap


### PR DESCRIPTION
Because ansible-core 2.16.3 gets upset if a role has a symlink to outside its directory.  Hopefully this should work better.

Also update provision_docker to a version with better symlinks.